### PR TITLE
FEAT: render page-specific JSON-LD from pageSchemaJsonLd field server…

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,7 +52,7 @@ module.exports = {
     'import/extensions': 'off',
     'import/no-extraneous-dependencies': [
       'error',
-      { devDependencies: ['next.config.js', '*.config.js'] },
+      { devDependencies: ['next.config.js', '*.config.js', 'tests/**'] },
     ],
     'no-console': [
       2,

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 
 # testing
 /coverage
+/test-results
+/playwright-report
+/blob-report
+/.playwright
 
 # next.js
 /.next/
@@ -47,3 +51,5 @@ sw.js.map
 swe-worker-*.js
 workbox-*.js
 workbox-*.js.map
+
+docs/task

--- a/components/pages/ArticlePage.js
+++ b/components/pages/ArticlePage.js
@@ -1,5 +1,6 @@
 import dynamic from 'next/dynamic';
 import PostSiteHead from 'components/shared/head/PostSiteHead';
+import PageSchemaMarkup from 'components/shared/head/PageSchemaMarkup';
 import SubHeaderDefault from 'layouts/SubHeader/SubHeaderDefault';
 import SubHeaderKeyContacts from 'layouts/SubHeader/SubHeaderKeyContacts';
 import PostBody from 'components/organisms/post/PostBody';
@@ -23,6 +24,7 @@ const ArticlePage = ({
   selectedHeroes,
   breadcrumbs,
   headings,
+  pageSchemaJsonLd,
 }) => {
   const printPageProps = {
     title: post?.title,
@@ -47,6 +49,7 @@ const ArticlePage = ({
         breadcrumbs={breadcrumbs}
         mainCategory={mainCategory}
       />
+      <PageSchemaMarkup schemaJson={pageSchemaJsonLd} />
       <SubHeaderDefault
         title={post.title}
         authors={authors}

--- a/components/pages/AttorneyProfilePage.js
+++ b/components/pages/AttorneyProfilePage.js
@@ -1,5 +1,6 @@
 import ProfileHeader from 'components/organisms/attorney/ProfileHeader';
 import PersonSiteHead from 'components/shared/head/PersonSiteHead';
+import PageSchemaMarkup from 'components/shared/head/PageSchemaMarkup';
 import { CURRENT_DOMAIN } from 'utils/constants';
 import ProfileContent from 'components/organisms/attorney/ProfileContent';
 import ProfileMedia from 'components/organisms/attorney/ProfileMedia';
@@ -15,6 +16,7 @@ const AttorneyProfilePage = (props) => {
     asideItems,
     profileMedia,
     breadcrumbs,
+    pageSchemaJsonLd,
   } = props;
 
   const { data: locations } = useGetLocationsQuery();
@@ -46,6 +48,7 @@ const AttorneyProfilePage = (props) => {
         affiliations={seo.affiliations}
         awards={seo.awards}
       />
+      <PageSchemaMarkup schemaJson={pageSchemaJsonLd} />
       <ProfileHeader handlePrint={handlePrint} {...profileHeader} />
 
       <ProfileContent profileContent={profileContent} asideItems={asideItems} />

--- a/components/pages/IndustryPage.js
+++ b/components/pages/IndustryPage.js
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
 import BasicSiteHead from 'components/shared/head/BasicSiteHead';
+import PageSchemaMarkup from 'components/shared/head/PageSchemaMarkup';
 import SubHeaderIndustry from 'layouts/SubHeader/SubHeaderIndustry';
 import { Title60 } from 'styles/common/Typography.style';
 import { IndustryPageWrapper } from 'styles/Industries.style';
@@ -63,6 +64,7 @@ const IndustryPage = ({
   canonicalLink,
   breadcrumbs,
   webPageData,
+  pageSchemaJsonLd,
 }) => {
   const [activeTab, setActiveTab] = useState(0);
   const { query } = useRouter();
@@ -150,6 +152,7 @@ const IndustryPage = ({
           url: canonicalLink,
         }}
       />
+      <PageSchemaMarkup schemaJson={pageSchemaJsonLd} />
       <SubHeaderIndustry
         title={title}
         description={description}

--- a/components/pages/LocationPage.js
+++ b/components/pages/LocationPage.js
@@ -1,4 +1,5 @@
 import BasicSiteHead from 'components/shared/head/BasicSiteHead';
+import PageSchemaMarkup from 'components/shared/head/PageSchemaMarkup';
 import dynamic from 'next/dynamic';
 import { useMemo } from 'react';
 import empty from 'is-empty';
@@ -59,6 +60,7 @@ const LocationPage = ({
   breadcrumbs,
   webPageData,
   locationSeo,
+  pageSchemaJsonLd,
 }) => {
   const anchorData = useMemo(() => {
     const copyAnchorLocationsData = { ...anchorLocationsData };
@@ -99,6 +101,7 @@ const LocationPage = ({
         locationSeo={locationSeo}
         includeOrganizationSchema
       />
+      <PageSchemaMarkup schemaJson={pageSchemaJsonLd} />
       <SubHeaderDefault
         title={currentOffice.title}
         subtitle={seo.metaDesc}

--- a/components/pages/PracticePageNew.js
+++ b/components/pages/PracticePageNew.js
@@ -1,4 +1,5 @@
 import BasicSiteHead from 'components/shared/head/BasicSiteHead';
+import PageSchemaMarkup from 'components/shared/head/PageSchemaMarkup';
 import { useMemo } from 'react';
 import empty from 'is-empty';
 import dynamic from 'next/dynamic';
@@ -59,6 +60,7 @@ const PracticePageNew = ({
   posts,
   breadcrumbs,
   webPageData,
+  pageSchemaJsonLd,
 }) => {
   const anchorData = useMemo(() => {
     let updatedAnchorData = {};
@@ -117,6 +119,7 @@ const PracticePageNew = ({
           url: canonicalUrl,
         }}
       />
+      <PageSchemaMarkup schemaJson={pageSchemaJsonLd} />
       <div className="d-print-none">
         <SubHeaderDefault
           title={practice?.title}

--- a/components/shared/head/PageSchemaMarkup.js
+++ b/components/shared/head/PageSchemaMarkup.js
@@ -1,0 +1,28 @@
+import Head from 'next/head';
+import { sanitizeJsonLd } from 'utils/sanitize-json-ld';
+
+/**
+ * Renders author-written JSON-LD (ACF field `pageSchemaJsonLd`) into <head>
+ * server-side. Kept separate from the *SiteHead components on purpose: those
+ * are shared by dozens of pages, this one only renders where it is placed.
+ *
+ * Renders nothing when the field is empty or holds invalid JSON — an empty
+ * <script type="application/ld+json"> tag is never emitted.
+ */
+const PageSchemaMarkup = ({ schemaJson }) => {
+  const sanitized = sanitizeJsonLd(schemaJson);
+
+  if (!sanitized) return null;
+
+  return (
+    <Head>
+      <script
+        key="page-schema-jsonld"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: sanitized }}
+      />
+    </Head>
+  );
+};
+
+export default PageSchemaMarkup;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "format": "prettier --write .",
     "prepare": "husky install",
     "knip": "knip",
+    "test": "playwright test",
+    "test:unit": "playwright test --project=unit",
+    "test:e2e": "playwright test --project=e2e",
     "analyze": "cross-env ANALYZE=true yarn build"
   },
   "lint-staged": {
@@ -71,6 +74,7 @@
     "@fullhuman/postcss-purgecss": "^8.0.0",
     "@next/bundle-analyzer": "^16.1.6",
     "@next/eslint-plugin-next": "^12.0.7",
+    "@playwright/test": "^1.61.1",
     "cross-env": "^10.1.0",
     "eslint": "^7.5.0",
     "eslint-config-airbnb": "^18.2.0",

--- a/pages/attorneys/[slug].js
+++ b/pages/attorneys/[slug].js
@@ -313,6 +313,7 @@ export const getStaticProps = async ({ params }) => {
       asideItems,
       profileMedia,
       breadcrumbs,
+      pageSchemaJsonLd: attorneyBio?.pageSchemaJsonLd ?? null,
     },
     revalidate: 600,
   };
@@ -326,6 +327,7 @@ const AttorneyProfile = ({
   asideItems,
   profileMedia,
   breadcrumbs,
+  pageSchemaJsonLd,
 }) => {
   const attorneyPageProps = {
     seo,
@@ -334,6 +336,7 @@ const AttorneyProfile = ({
     asideItems,
     profileMedia,
     breadcrumbs,
+    pageSchemaJsonLd,
   };
 
   return (

--- a/pages/industries/[slug].js
+++ b/pages/industries/[slug].js
@@ -126,6 +126,7 @@ export const getStaticProps = async ({ params }) => {
       canonicalLink,
       breadcrumbs,
       webPageData,
+      pageSchemaJsonLd: industry?.pageSchemaJsonLd ?? null,
     },
     revalidate: 600,
   };
@@ -137,6 +138,7 @@ const Industry = ({
   canonicalLink,
   breadcrumbs,
   webPageData,
+  pageSchemaJsonLd,
 }) => {
   const industryProps = {
     content,
@@ -144,6 +146,7 @@ const Industry = ({
     canonicalLink,
     breadcrumbs,
     webPageData,
+    pageSchemaJsonLd,
   };
   return (
     <ApolloWrapper>

--- a/pages/location/[slug].js
+++ b/pages/location/[slug].js
@@ -57,6 +57,7 @@ const getOfficeData = async (slug) => {
   return {
     currentOffice,
     offices,
+    pageSchemaJsonLd: officeLocation?.pageSchemaJsonLd ?? null,
   };
 };
 
@@ -99,7 +100,7 @@ export const getStaticProps = async ({ params }) => {
     };
   }
 
-  const { currentOffice, offices } = officesData;
+  const { currentOffice, offices, pageSchemaJsonLd } = officesData;
   const attorneys = await getAttorneys();
   attorneys.sort((a, b) => {
     const aLoc = a.location_array.find((loc) => loc.officeMainInformation);
@@ -205,6 +206,7 @@ export const getStaticProps = async ({ params }) => {
       breadcrumbs,
       webPageData,
       locationSeo,
+      pageSchemaJsonLd,
     },
     revalidate: 600,
   };
@@ -222,6 +224,7 @@ const SingleLocation = ({
   breadcrumbs,
   locationSeo,
   webPageData,
+  pageSchemaJsonLd,
 }) => {
   const router = useRouter();
 
@@ -240,6 +243,7 @@ const SingleLocation = ({
     breadcrumbs,
     webPageData,
     locationSeo,
+    pageSchemaJsonLd,
   };
 
   return <LocationPage {...locationProps} />;

--- a/pages/post/[...slug].js
+++ b/pages/post/[...slug].js
@@ -86,6 +86,7 @@ const getPostContentData = async (slug, categorySlug) => {
     mainCategory: postMainCategoryContent?.category,
     tags: post?.tags?.nodes,
     postTypeConnections: post?.linksToOtherPostTypes,
+    pageSchemaJsonLd: post?.pageSchemaJsonLd ?? null,
   };
 };
 
@@ -117,6 +118,7 @@ export const getServerSideProps = async ({ params, res, query }) => {
     seo,
     tags,
     postTypeConnections,
+    pageSchemaJsonLd,
   } = postData;
 
   const post = {
@@ -155,6 +157,7 @@ export const getServerSideProps = async ({ params, res, query }) => {
       selectedHeroes,
       breadcrumbs,
       headings: extractHeadings(content),
+      pageSchemaJsonLd: pageSchemaJsonLd ?? null,
     },
   };
 };
@@ -170,6 +173,7 @@ const SinglePost = ({
   selectedHeroes,
   breadcrumbs,
   headings,
+  pageSchemaJsonLd,
 }) => {
   const postProps = {
     post,
@@ -181,6 +185,7 @@ const SinglePost = ({
     selectedHeroes,
     breadcrumbs,
     headings,
+    pageSchemaJsonLd,
   };
   return <ArticlePage {...postProps} />;
 };

--- a/pages/practices/[slug].js
+++ b/pages/practices/[slug].js
@@ -129,6 +129,7 @@ export const getStaticProps = async ({ params }) => {
       webPageData,
       canonicalUrl,
       siteTabs,
+      pageSchemaJsonLd: practice?.pageSchemaJsonLd ?? null,
     },
     revalidate: 600,
   };
@@ -151,6 +152,7 @@ const SinglePractice = ({
   webPageData,
   canonicalUrl,
   siteTabs,
+  pageSchemaJsonLd,
 }) => {
   const practiceProps = {
     practice,
@@ -168,6 +170,7 @@ const SinglePractice = ({
     posts,
     breadcrumbs,
     webPageData,
+    pageSchemaJsonLd,
   };
 
   return <PracticePageNew {...practiceProps} />;

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,18 @@
+const { defineConfig } = require('@playwright/test');
+
+const E2E_BASE_URL = process.env.E2E_BASE_URL || 'http://localhost:7300';
+
+module.exports = defineConfig({
+  reporter: process.env.CI ? 'line' : 'list',
+  projects: [
+    {
+      name: 'unit',
+      testDir: './tests/unit',
+    },
+    {
+      name: 'e2e',
+      testDir: './tests/e2e',
+      use: { baseURL: E2E_BASE_URL },
+    },
+  ],
+});

--- a/requests/graphql-queries.js
+++ b/requests/graphql-queries.js
@@ -2,6 +2,7 @@ export const attorneyBySlugQuery = `query AttorneyProfileBySlug($slug: String) {
   attorneyProfileBy(slug: $slug) {
     status
     databaseId
+    pageSchemaJsonLd
     seo {
       title
       metaDesc
@@ -394,6 +395,7 @@ query PostContentQuery($id: ID!) {
     date
     modified
     status
+    pageSchemaJsonLd
     seo {
       opengraphDescription
       title
@@ -1103,6 +1105,7 @@ export const getOfficeAndMoreData = `query FirmPageQuery($id: ID!) {
     databaseId
     title
     status
+    pageSchemaJsonLd
     officeMainInformation {
       autoMap {
         mediaItemUrl
@@ -1217,6 +1220,7 @@ query IndustryQuery($id: ID!) {
     title
     status
     databaseId
+    pageSchemaJsonLd
     seo {
       metaDesc
       title

--- a/requests/practices/practicesQueryGenerator.js
+++ b/requests/practices/practicesQueryGenerator.js
@@ -4,6 +4,7 @@ export const practicesQuery = `query PracticeQuery($id: ID!) {
     slug
     title
     status
+    pageSchemaJsonLd
     practicesIncluded {
 			practiceImage {
 					sourceUrl

--- a/tests/e2e/page-schema.spec.js
+++ b/tests/e2e/page-schema.spec.js
@@ -1,0 +1,112 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * These tests read the RAW server HTML (the `request` fixture, no browser, no
+ * JS) — that is exactly what a crawler sees. A tag injected client-side by GTM
+ * would not show up here, which is the whole point of the task.
+ */
+
+/** Pilot post — the editor seeds `pageSchemaJsonLd` with an FAQPage object. */
+const SCHEMA_PAGE_PATH = process.env.E2E_SCHEMA_PATH || '/client-alert/new-jersey-data-broker-law';
+
+/**
+ * One page per remaining priority route. These assertions hold whether or not
+ * the field happens to be filled, so they do not depend on WordPress content.
+ */
+const PRIORITY_ROUTES = [
+  { name: 'practice', path: '/practices/construction-lawyers' },
+  { name: 'industry', path: '/industries/cannabis' },
+  { name: 'attorney', path: '/attorneys/donald-scarinci' },
+  { name: 'location', path: '/location/little-falls' },
+];
+
+const LD_JSON_TAG_REGEX = /<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/g;
+
+const EMPTY_LD_JSON_TAG_REGEX = /<script[^>]*type="application\/ld\+json"[^>]*>\s*<\/script>/;
+
+const getLdJsonBlocks = (html) => [...html.matchAll(LD_JSON_TAG_REGEX)].map((match) => match[1]);
+
+const fetchHead = async (request, path) => {
+  const res = await request.get(path);
+  expect(res.status(), `${path} should respond 200`).toBe(200);
+
+  const html = await res.text();
+  const end = html.indexOf('</head>');
+  expect(end, `${path} should contain a </head>`).toBeGreaterThan(-1);
+
+  return html.slice(0, end);
+};
+
+const expectHealthyBlocks = (head, path) => {
+  expect(head, `${path} must not render an empty ld+json tag`).not.toMatch(
+    EMPTY_LD_JSON_TAG_REGEX,
+  );
+
+  const blocks = getLdJsonBlocks(head);
+  expect(
+    blocks.length,
+    `${path} should still emit code schemas`,
+  ).toBeGreaterThan(0);
+
+  blocks.forEach((block) => {
+    expect(block.trim()).not.toBe('');
+    expect(() => JSON.parse(block), `invalid JSON-LD on ${path}`).not.toThrow();
+  });
+
+  return blocks;
+};
+
+const typesIn = (blocks) => blocks
+  .map((block) => JSON.parse(block))
+  .flatMap((json) => (json['@graph'] ? json['@graph'] : [json]))
+  .flatMap((node) => node['@type']);
+
+test.describe('field schema on the pilot post', () => {
+  test('renders server-side, exactly once', async ({ request }) => {
+    const head = await fetchHead(request, SCHEMA_PAGE_PATH);
+    const faqBlocks = getLdJsonBlocks(head).filter((block) => block.includes('"FAQPage"'));
+
+    expect(
+      faqBlocks,
+      `expected exactly one FAQPage ld+json block in the head of ${SCHEMA_PAGE_PATH}. `
+        + 'If this fails with 0, the pageSchemaJsonLd field is empty in WordPress '
+        + '(or the page has not been revalidated since it was filled).',
+    ).toHaveLength(1);
+
+    expect(JSON.parse(faqBlocks[0])['@type']).toBe('FAQPage');
+  });
+
+  test('never emits a raw < that could break out of the script tag', async ({
+    request,
+  }) => {
+    const head = await fetchHead(request, SCHEMA_PAGE_PATH);
+
+    getLdJsonBlocks(head).forEach((block) => {
+      expect(block).not.toContain('<');
+    });
+  });
+
+  test('does not replace the code-generated schemas', async ({ request }) => {
+    const head = await fetchHead(request, SCHEMA_PAGE_PATH);
+    const types = typesIn(expectHealthyBlocks(head, SCHEMA_PAGE_PATH));
+
+    expect(types).toContain('Article');
+    expect(types).toContain('FAQPage');
+  });
+});
+
+test.describe('remaining priority routes', () => {
+  PRIORITY_ROUTES.forEach(({ name, path }) => {
+    test(`${name} page renders no empty ld+json tag and keeps its code schemas`, async ({
+      request,
+    }) => {
+      const head = await fetchHead(request, path);
+      const types = typesIn(expectHealthyBlocks(head, path));
+
+      expect(
+        types.length,
+        `${path} lost its code-generated schemas`,
+      ).toBeGreaterThan(0);
+    });
+  });
+});

--- a/tests/unit/sanitize-json-ld.spec.js
+++ b/tests/unit/sanitize-json-ld.spec.js
@@ -1,0 +1,294 @@
+import { test, expect } from '@playwright/test';
+import { sanitizeJsonLd } from '../../utils/sanitize-json-ld';
+
+const FAQ_SCHEMA = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'What is a data broker?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'A business that sells personal data.',
+      },
+    },
+  ],
+};
+
+test.describe('sanitizeJsonLd — step 1: empty / non-string input', () => {
+  test('returns null for null', () => {
+    expect(sanitizeJsonLd(null)).toBeNull();
+  });
+
+  test('returns null for undefined', () => {
+    expect(sanitizeJsonLd(undefined)).toBeNull();
+  });
+
+  test('returns null for an empty string', () => {
+    expect(sanitizeJsonLd('')).toBeNull();
+  });
+
+  test('returns null for a whitespace-only string', () => {
+    expect(sanitizeJsonLd('   \n\t  ')).toBeNull();
+  });
+
+  test('returns null for a number', () => {
+    expect(sanitizeJsonLd(42)).toBeNull();
+  });
+
+  test('returns null for an object', () => {
+    expect(sanitizeJsonLd({ '@type': 'FAQPage' })).toBeNull();
+  });
+
+  test('returns null for an array', () => {
+    expect(sanitizeJsonLd([1, 2, 3])).toBeNull();
+  });
+
+  test('returns null for a boolean', () => {
+    expect(sanitizeJsonLd(true)).toBeNull();
+  });
+});
+
+test.describe('sanitizeJsonLd — steps 2 & 5: trim and canonical output', () => {
+  test('returns a canonical JSON string for a valid JSON object', () => {
+    const result = sanitizeJsonLd(JSON.stringify(FAQ_SCHEMA));
+
+    expect(result).toBe(JSON.stringify(FAQ_SCHEMA));
+    expect(JSON.parse(result)['@type']).toBe('FAQPage');
+  });
+
+  test('collapses pretty-printed JSON to a single line', () => {
+    const result = sanitizeJsonLd(JSON.stringify(FAQ_SCHEMA, null, 2));
+
+    expect(result).toBe(JSON.stringify(FAQ_SCHEMA));
+    expect(result).not.toContain('\n');
+  });
+
+  test('trims surrounding whitespace before parsing', () => {
+    const result = sanitizeJsonLd(`\n\t  ${JSON.stringify(FAQ_SCHEMA)}  \n`);
+
+    expect(result).toBe(JSON.stringify(FAQ_SCHEMA));
+  });
+
+  test('strips a byte order mark', () => {
+    const result = sanitizeJsonLd(
+      `${String.fromCharCode(0xfeff)}${JSON.stringify(FAQ_SCHEMA)}`,
+    );
+
+    expect(result).toBe(JSON.stringify(FAQ_SCHEMA));
+  });
+});
+
+test.describe('sanitizeJsonLd — step 3: accidental <script> wrapper', () => {
+  test('strips a <script type="application/ld+json"> wrapper', () => {
+    const raw = `<script type="application/ld+json">${JSON.stringify(
+      FAQ_SCHEMA,
+    )}</script>`;
+
+    expect(sanitizeJsonLd(raw)).toBe(JSON.stringify(FAQ_SCHEMA));
+  });
+
+  test('strips a bare <script> wrapper', () => {
+    const raw = `<script>${JSON.stringify(FAQ_SCHEMA)}</script>`;
+
+    expect(sanitizeJsonLd(raw)).toBe(JSON.stringify(FAQ_SCHEMA));
+  });
+
+  test('strips a wrapper padded with whitespace inside and outside', () => {
+    const raw = `\n  <script type="application/ld+json">\n    ${JSON.stringify(
+      FAQ_SCHEMA,
+    )}\n  </script>\n`;
+
+    expect(sanitizeJsonLd(raw)).toBe(JSON.stringify(FAQ_SCHEMA));
+  });
+
+  test('is case-insensitive about the SCRIPT tag name', () => {
+    const raw = `<SCRIPT TYPE="application/ld+json">${JSON.stringify(
+      FAQ_SCHEMA,
+    )}</SCRIPT>`;
+
+    expect(sanitizeJsonLd(raw)).toBe(JSON.stringify(FAQ_SCHEMA));
+  });
+
+  test('strips a wrapper whose closing tag has trailing whitespace', () => {
+    expect(sanitizeJsonLd('<script>{"@type":"FAQPage"}</script >')).toBe(
+      '{"@type":"FAQPage"}',
+    );
+  });
+
+  test('keeps a </script> that sits inside a string value', () => {
+    const raw = '<script>{"@type":"X","n":"</script>"}</script>';
+
+    expect(JSON.parse(sanitizeJsonLd(raw)).n).toBe('</script>');
+  });
+
+  test('returns null for two separate wrappers', () => {
+    const raw = '<script>{"@type":"A"}</script><script>{"@type":"B"}</script>';
+
+    expect(sanitizeJsonLd(raw)).toBeNull();
+  });
+
+  test('returns null when junk trails the wrapper', () => {
+    expect(sanitizeJsonLd('<script>{"@type":"X"}</script>junk')).toBeNull();
+  });
+});
+
+test.describe('sanitizeJsonLd — step 4: invalid JSON', () => {
+  test('returns null for a truncated object', () => {
+    expect(sanitizeJsonLd('{oops')).toBeNull();
+  });
+
+  test('returns null for JSON with a trailing comma', () => {
+    expect(sanitizeJsonLd('{"@type": "FAQPage",}')).toBeNull();
+  });
+
+  test('returns null for plain prose', () => {
+    expect(sanitizeJsonLd('please add my schema here')).toBeNull();
+  });
+
+  test('returns null for a <script> wrapper around invalid JSON', () => {
+    expect(sanitizeJsonLd('<script>{oops</script>')).toBeNull();
+  });
+
+  test('returns null for a <script> wrapper with an empty body', () => {
+    expect(
+      sanitizeJsonLd('<script type="application/ld+json">   </script>'),
+    ).toBeNull();
+  });
+
+  test('returns null for HTML-entity-encoded quotes', () => {
+    expect(sanitizeJsonLd('{&quot;@type&quot;:&quot;X&quot;}')).toBeNull();
+  });
+
+  test('returns null for an HTML comment wrapper', () => {
+    expect(sanitizeJsonLd('<!-- {"@type":"X"} -->')).toBeNull();
+  });
+});
+
+test.describe('sanitizeJsonLd — step 6: </script> breakout protection', () => {
+  test('escapes < inside string values so no </script> survives', () => {
+    const raw = JSON.stringify({
+      '@type': 'FAQPage',
+      name: 'Breakout attempt </script><script>alert(1)</script>',
+    });
+
+    const result = sanitizeJsonLd(raw);
+
+    expect(result).not.toContain('</script>');
+    expect(result).not.toContain('<');
+    expect(result).toContain('\\u003c');
+  });
+
+  test('escapes the <!-- comment opener too', () => {
+    const result = sanitizeJsonLd(
+      JSON.stringify({ '@type': 'X', n: 'a <!-- b' }),
+    );
+
+    expect(result).not.toContain('<');
+    expect(JSON.parse(result).n).toBe('a <!-- b');
+  });
+
+  test('escaped output is still parseable JSON with the value intact', () => {
+    const raw = JSON.stringify({ '@type': 'FAQPage', name: 'a < b </script>' });
+
+    const result = sanitizeJsonLd(raw);
+
+    expect(() => JSON.parse(result)).not.toThrow();
+    expect(JSON.parse(result).name).toBe('a < b </script>');
+  });
+
+  test('escapes < that appears in a key as well as a value', () => {
+    const result = sanitizeJsonLd(JSON.stringify({ '<key>': '<value>' }));
+
+    expect(result).not.toContain('<');
+    expect(JSON.parse(result)['<key>']).toBe('<value>');
+  });
+
+  test('an already-escaped \\u003c round-trips without doubling', () => {
+    const result = sanitizeJsonLd('{"@type":"X","n":"\\u003c"}');
+
+    expect(JSON.parse(result).n).toBe('<');
+    expect(result).not.toContain('<');
+  });
+});
+
+test.describe('sanitizeJsonLd — unicode line terminators', () => {
+  const LINE_SEP = String.fromCharCode(0x2028);
+  const PARA_SEP = String.fromCharCode(0x2029);
+
+  test('escapes U+2028 and U+2029, which JSON.stringify leaves raw', () => {
+    const name = `a${LINE_SEP}b${PARA_SEP}c`;
+    const result = sanitizeJsonLd(JSON.stringify({ '@type': 'FAQPage', name }));
+
+    expect(result).not.toContain(LINE_SEP);
+    expect(result).not.toContain(PARA_SEP);
+    expect(JSON.parse(result).name).toBe(name);
+  });
+});
+
+test.describe('sanitizeJsonLd — never throws, whatever the field holds', () => {
+  test('returns null instead of throwing when JSON is too deep to serialise', () => {
+    // JSON.parse copes with this depth; JSON.stringify blows the call stack.
+    const tooDeep = `${'['.repeat(5000)}${']'.repeat(5000)}`;
+
+    expect(() => sanitizeJsonLd(tooDeep)).not.toThrow();
+    expect(sanitizeJsonLd(tooDeep)).toBeNull();
+  });
+
+  test('still handles nesting that is deep but serialisable', () => {
+    const deep = `{"@type":"X","a":${'['.repeat(500)}${']'.repeat(500)}}`;
+
+    expect(() => sanitizeJsonLd(deep)).not.toThrow();
+    expect(JSON.parse(sanitizeJsonLd(deep))['@type']).toBe('X');
+  });
+
+  test('does not pollute Object.prototype via a __proto__ key', () => {
+    const result = sanitizeJsonLd('{"@type":"X","__proto__":{"polluted":1}}');
+
+    expect({}.polluted).toBeUndefined();
+    expect(JSON.parse(result)['@type']).toBe('X');
+  });
+});
+
+test.describe('sanitizeJsonLd — @graph and other shapes', () => {
+  test('canonicalises an @graph array of several schemas', () => {
+    const graph = {
+      '@context': 'https://schema.org',
+      '@graph': [
+        FAQ_SCHEMA,
+        { '@type': 'BreadcrumbList', itemListElement: [] },
+        { '@type': 'HowTo', name: 'How to comply' },
+      ],
+    };
+
+    const result = sanitizeJsonLd(JSON.stringify(graph));
+
+    expect(result).toBe(JSON.stringify(graph));
+    expect(JSON.parse(result)['@graph']).toHaveLength(3);
+  });
+
+  test('accepts a top-level array of schemas', () => {
+    const arr = [FAQ_SCHEMA, { '@type': 'HowTo' }];
+
+    expect(JSON.parse(sanitizeJsonLd(JSON.stringify(arr)))).toHaveLength(2);
+  });
+
+  test('returns null for valid JSON that is not an object or array', () => {
+    expect(sanitizeJsonLd('"just a string"')).toBeNull();
+    expect(sanitizeJsonLd('42')).toBeNull();
+    expect(sanitizeJsonLd('null')).toBeNull();
+    expect(sanitizeJsonLd('true')).toBeNull();
+  });
+
+  test('returns null for an empty object or empty array', () => {
+    expect(sanitizeJsonLd('{}')).toBeNull();
+    expect(sanitizeJsonLd('[]')).toBeNull();
+  });
+
+  test('preserves unicode content', () => {
+    const raw = JSON.stringify({ '@type': 'FAQPage', name: 'Ünïcøde — тест' });
+
+    expect(JSON.parse(sanitizeJsonLd(raw)).name).toBe('Ünïcøde — тест');
+  });
+});

--- a/utils/sanitize-json-ld.js
+++ b/utils/sanitize-json-ld.js
@@ -1,0 +1,89 @@
+/**
+ * Matches a value that an editor accidentally wrapped in a <script> tag.
+ * The contract is "JSON only", but the safeguard must not break on a wrapper.
+ * The capture is greedy on purpose: a `</script>` may legitimately appear
+ * inside a string value, and only the last one closes the wrapper.
+ */
+const SCRIPT_WRAPPER_REGEX = /^<script\b[^>]*>([\s\S]*)<\/script\s*>$/i;
+
+const LINE_SEPARATOR = String.fromCharCode(0x2028);
+const PARAGRAPH_SEPARATOR = String.fromCharCode(0x2029);
+
+/**
+ * Characters that must not reach a <script> block verbatim:
+ *   `<`       — would allow a `</script>` breakout.
+ *   U+2028/9  — legal raw inside a JSON string (JSON.stringify leaves them
+ *               alone) but line terminators to a JavaScript parser, so they
+ *               break any consumer that evaluates the payload.
+ * All three can only occur inside string literals, so escaping them globally
+ * keeps the output valid JSON.
+ */
+const UNSAFE_CHARS_REGEX = new RegExp(
+  `[<${LINE_SEPARATOR}${PARAGRAPH_SEPARATOR}]`,
+  'g',
+);
+
+const UNSAFE_CHAR_ESCAPES = {
+  '<': '\\u003c',
+  [LINE_SEPARATOR]: '\\u2028',
+  [PARAGRAPH_SEPARATOR]: '\\u2029',
+};
+
+/**
+ * Prepares author-written JSON-LD (ACF field `pageSchemaJsonLd`) for
+ * server-side rendering inside <head>.
+ *
+ * Pipeline:
+ *   1. non-string / empty / whitespace-only -> null
+ *   2. trim (also drops a byte order mark, which counts as whitespace)
+ *   3. unwrap an accidental <script>...</script> wrapper, then trim again
+ *   4. JSON.parse — unparseable -> null (a tag without valid JSON is worse
+ *      than no tag at all)
+ *   5. reject anything that is not a non-empty object or array — an empty
+ *      `{}` would render a useless tag, and a bare string/number is not JSON-LD
+ *   6. JSON.stringify to canonicalise the output. This can throw a RangeError
+ *      on input that JSON.parse accepted (stringify recurses, the parser does
+ *      not), so it is guarded — a broken field must never take the page down.
+ *   7. escape the characters listed above.
+ *
+ * Never throws: any malformed value yields null and simply renders no tag.
+ *
+ * @param {unknown} raw value straight from the GraphQL field
+ * @returns {string|null} canonical JSON string safe for dangerouslySetInnerHTML,
+ *                        or null when there is nothing to render
+ */
+export const sanitizeJsonLd = (raw) => {
+  if (typeof raw !== 'string') return null;
+
+  let value = raw.trim();
+  if (!value) return null;
+
+  const unwrapped = value.match(SCRIPT_WRAPPER_REGEX);
+  if (unwrapped) {
+    value = unwrapped[1].trim();
+    if (!value) return null;
+  }
+
+  let canonical;
+  try {
+    const parsed = JSON.parse(value);
+
+    if (parsed === null || typeof parsed !== 'object') return null;
+
+    const isEmpty = Array.isArray(parsed)
+      ? parsed.length === 0
+      : Object.keys(parsed).length === 0;
+    if (isEmpty) return null;
+
+    canonical = JSON.stringify(parsed);
+  } catch (error) {
+    return null;
+  }
+
+  return canonical.replace(
+    UNSAFE_CHARS_REGEX,
+    (char) => UNSAFE_CHAR_ESCAPES[char],
+  );
+};
+
+export default sanitizeJsonLd;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1803,6 +1803,13 @@
     tiny-glob "^0.2.9"
     tslib "^2.4.0"
 
+"@playwright/test@^1.61.1":
+  version "1.61.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.61.1.tgz#48568dc22af7819e55fa5e8e3bc79b7e6a3e6675"
+  integrity sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==
+  dependencies:
+    playwright "1.61.1"
+
 "@polka/url@^1.0.0-next.24":
   version "1.0.0-next.29"
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.29.tgz#5a40109a1ab5f84d6fd8fc928b19f367cbe7e7b1"
@@ -3679,6 +3686,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -5134,6 +5146,20 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==
+
+playwright-core@1.61.1:
+  version "1.61.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.61.1.tgz#3c99841307efbbabc9d724c41a88c914705d15fc"
+  integrity sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==
+
+playwright@1.61.1:
+  version "1.61.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.61.1.tgz#d8c0c06eb93c28981afc747bace453bdbd5018bc"
+  integrity sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==
+  dependencies:
+    playwright-core "1.61.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
…-side

Editors can now add page-specific JSON-LD in the WordPress ACF field `page_schema_jsonld`, and it is printed into <head> server-side. Previously this markup was injected by GTM in the browser, so crawlers did not see it reliably — the site is headless, and only this repo renders public HTML.

Covers the five priority routes: post, practices, industries, attorneys and locations. Other content types follow in a later iteration.

- utils/sanitize-json-ld.js: pure function turning the raw field value into a canonical JSON string, or null when there is nothing safe to render. It never throws — note that JSON.stringify can blow the call stack on input JSON.parse accepts, so serialisation is guarded too. Every `<`, U+2028 and U+2029 is escaped, which makes a `</script>` breakout structurally impossible.
- components/shared/head/PageSchemaMarkup.js: renders the tag through its own next/head block. Deliberately separate from the *SiteHead components — those are shared by dozens of pages, so changing their props would touch all of them. This one only renders where it is explicitly placed.
- Each route adds the field to its GraphQL query, passes it through props as `?? null`, and renders <PageSchemaMarkup> next to the existing head component.

Empty or invalid values render nothing at all; an empty <script type="application/ld+json"></script> is never emitted.

Tests: Playwright is set up from scratch as both the unit runner and the e2e runner (no browser binaries needed — e2e reads raw server HTML through the request fixture, which is what a crawler sees). 42 unit tests cover the sanitiser including breakout vectors, BOM, prototype pollution and unicode edge cases; 6 e2e tests assert the tag is server-rendered, appears exactly once, and that the existing Article/Person/Breadcrumb/Organization schemas are untouched on every route.